### PR TITLE
Change default Beaker cache type to file

### DIFF
--- a/bottle_cas/client.py
+++ b/bottle_cas/client.py
@@ -213,7 +213,9 @@ class CASMiddleware(SessionMiddleware):
     def get_beaker_opts(self):
         import config
         return  {
-            'session.type': 'memory',
+            'session.type': config.BEAKER_TYPE,
+            'session.data_dir': config.BEAKER_DATA_DIR,
+            'session.lock_dir': config.BEAKER_LOCK_DIR,
             'session.cookie_expires': True,
             'session.secure': not config.ALLOW_HTTP,
             'session.timeout': config.TIMEOUT,

--- a/bottle_cas/config.py
+++ b/bottle_cas/config.py
@@ -14,7 +14,8 @@ COOKIE_PATH = '/'
 TIMEOUT = 600
 
 # Your cookie encryption key
-SECRET = "SUPER_SECRET_PASSPHRASE"
+# Change and uncomment this to remove errors
+# SECRET = "SUPER_SECRET_PASSPHRASE"
 
 # Store sessions in non https connections
 # WARNING: this makes session hijacking silly easy. PLS set this to False for production use

--- a/bottle_cas/config.py
+++ b/bottle_cas/config.py
@@ -23,3 +23,13 @@ ALLOW_HTTP = True
 # Turn on debug messages in logfiles
 DEBUG = 1
 
+# Configure Beaker session type
+# http://beaker.readthedocs.io/en/latest/configuration.html
+# File is default to allow multiple instances of beaker to share cached data
+BEAKER_TYPE = 'file'
+
+# Specifies Beaker data location
+BEAKER_DATA_DIR = '/tmp/beaker/data'
+
+# Specifies Beaker lock location
+BEAKER_LOCK_DIR = '/tmp/beaker/lock'

--- a/examples/cleanup.sh
+++ b/examples/cleanup.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+BEAKER_DATA_DIR=/tmp/beaker/data
+BEAKER_LOCK_DIR=/tmp/beaker/lock
+
+find $BEAKER_DATA_DIR -mmin +60 -delete
+find $BEAKER_DATA_DIR -type d -empty -delete
+find $BEAKER_LOCK_DIR -mmin +60 -delete
+find $BEAKER_LOCK_DIR -type d -empty -delete
+

--- a/examples/cleanup.sh
+++ b/examples/cleanup.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# Shell script to clean up defualt beaker directory
+# Copy this script to /root and install in CRON with the quoted string on the
+# next line
+# "0 2 * * * /root/cleanup.sh &> /dev/null"
+
 BEAKER_DATA_DIR=/tmp/beaker/data
 BEAKER_LOCK_DIR=/tmp/beaker/lock
 


### PR DESCRIPTION
This change allows the cache to be shared among multiple workers (e.g. when running an app using multiple uWSGI workers).